### PR TITLE
feat: re-export tokio runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,4 @@ authors = ["Duyet Le <me@duyet.net>"]
 anyhow = "1.0.65"
 deno_core = "0.154.0"
 deno_console = "0.72.0"
-
-[dev-dependencies]
 tokio = { version = "1.21.2", features = ["rt", "macros", "rt-multi-thread"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use deno_core::{FsModuleLoader, JsRuntime, RuntimeOptions};
 use std::{collections::HashMap, fmt::Display, rc::Rc};
 
 pub use deno_core::{anyhow, op};
+pub use tokio::runtime::Runtime;
 
 /// Deno runtime
 pub struct DenoRunner {

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1,0 +1,22 @@
+use deno_runner::{Builder, Runtime};
+use std::collections::HashMap;
+
+#[test]
+fn test_tokio_runtime() {
+    // Using re-exported tokio runtime
+    let rt = Runtime::new().unwrap();
+    let out = rt.block_on(async {
+        let custom_code = r#"
+            const add = (a, b) => a + b;
+            add(a, b)
+        "#;
+
+        let runner = Builder::new().build();
+        let vars = HashMap::from([("a", 1), ("b", 2)]);
+        let result = runner.run(custom_code, Some(vars)).await.unwrap();
+
+        result
+    });
+
+    assert_eq!(out, "3");
+}


### PR DESCRIPTION
```rust
use deno_runner::{Builder, Runtime};
use std::collections::HashMap;

#[test]
fn test_tokio_runtime() {
    // Using re-exported tokio runtime
    let rt = Runtime::new().unwrap();
    let out = rt.block_on(async {
        let custom_code = r#"
            const add = (a, b) => a + b;
            add(a, b)
        "#;

        let runner = Builder::new().build();
        let vars = HashMap::from([("a", 1), ("b", 2)]);
        let result = runner.run(custom_code, Some(vars)).await.unwrap();

        result
    });

    assert_eq!(out, "3");
}
```